### PR TITLE
Fixed filters selected on the previous page persists on the next page

### DIFF
--- a/adminforth/spa/src/router/index.ts
+++ b/adminforth/spa/src/router/index.ts
@@ -1,6 +1,6 @@
-import { createRouter, createWebHistory } from 'vue-router'
-import ResourceParent from '@/views/ResourceParent.vue'
-import { useUserStore } from '@/stores/user'
+import { createRouter, createWebHistory } from 'vue-router';
+import ResourceParent from '@/views/ResourceParent.vue';
+import { useFiltersStore } from '@/stores/filters';
 /* IMPORTANT:ADMINFORTH ROUTES IMPORTS */
 
 const router = createRouter({
@@ -51,13 +51,17 @@ const router = createRouter({
 
         },
       ]
-    }, 
+    },
     /* IMPORTANT:ADMINFORTH ROUTES */
   ]
 })
 
-
-
-
+router.beforeEach((to, from, next) => {
+  const filterStore = useFiltersStore();
+  if (to.path.startsWith('/resource/')) {
+    filterStore.clearFilters();
+  }
+  next()
+})
 
 export default router

--- a/adminforth/spa/src/stores/filters.ts
+++ b/adminforth/spa/src/stores/filters.ts
@@ -1,9 +1,8 @@
-import { ref } from 'vue'
-import { defineStore } from 'pinia'
-import { callAdminForthApi } from '@/utils';
+import { ref, type Ref } from 'vue';
+import { defineStore } from 'pinia';
 
 export const useFiltersStore = defineStore('filters', () => {
-    const filters = ref([]);
+    const filters: Ref<any[]> = ref([]);
     const setFilter = (filter: any) => {
         filters.value = [...filters.value, filter];
     }
@@ -16,7 +15,5 @@ export const useFiltersStore = defineStore('filters', () => {
     const clearFilters = () => {
         filters.value = [];
     }
-    return {setFilter, getFilters,clearFilters, filters,setFilters}
-    })
-
-    
+    return {setFilter, getFilters, clearFilters, filters, setFilters}
+})


### PR DESCRIPTION
Fixed a bug when filters selected on the resource page persist on the next visited page, therefore get_resource_data failed because of payload with filters of non-existing columns.
