### PR TITLE
added try catch to callApi + alert for catch statement

### DIFF
--- a/adminforth/spa/src/utils.ts
+++ b/adminforth/spa/src/utils.ts
@@ -23,13 +23,19 @@ export async function callApi({path, method, body=undefined}: {
     body: JSON.stringify(body),
   };
   const fullPath = `${import.meta.env.VITE_ADMINFORTH_PUBLIC_PATH || ''}${path}`;
-  const r = await fetch(fullPath, options);
-  if (r.status == 401 ) {
-    useUserStore().unauthorize();
-    await router.push({ name: 'login' });
-    return null;
-  } 
-  return await r.json();
+  try {
+    const r = await fetch(fullPath, options);
+    if (r.status == 401 ) {
+      useUserStore().unauthorize();
+      await router.push({ name: 'login' });
+      return null;
+    } 
+    return await r.json();
+  } catch(e){
+    window.adminforth.alert({variant:'danger', message:'Something went wrong, please try again later',})
+    console.error('error',e);
+  }
+  
 }
 
 export async function callAdminForthApi({ path, method, body=undefined, headers=undefined }: {


### PR DESCRIPTION
https://web.tracklify.com/project/2b7ZVgE5/AdminForth/354/cQ3CFUag/if-back-crashes-with-500-butto

I am not sure , coz u asked about handling only 500 status. By I think it would be better to show alert if any error will be catched in callApi function.