### PR TITLE
don't commit generated local and prod secret files

### DIFF
--- a/adminforth/commands/createApp/templates/.gitignore.hbs
+++ b/adminforth/commands/createApp/templates/.gitignore.hbs
@@ -3,3 +3,5 @@ node_modules/
 
 # dotenv environment variable files
 .env
+.env.local
+.env.prod


### PR DESCRIPTION
The template generates two files, .env.local and .env.prod with sensitive values (database connection string with secrets). A user could easily add these by mistake to their git commit.